### PR TITLE
fix: protect password from being serialized

### DIFF
--- a/src/auth/stubs/make/model/user_with_access_tokens.stub
+++ b/src/auth/stubs/make/model/user_with_access_tokens.stub
@@ -27,7 +27,7 @@ export default class {{ modelName }} extends compose(BaseModel, AuthFinder) {
   @column()
   declare email: string
 
-  @column()
+  @column({ serializeAs: null })
   declare password: string
 
   @column.dateTime({ autoCreate: true })

--- a/src/auth/stubs/make/model/user_with_basic_auth.stub
+++ b/src/auth/stubs/make/model/user_with_basic_auth.stub
@@ -26,7 +26,7 @@ export default class {{ modelName }} extends compose(BaseModel, AuthFinder) {
   @column()
   declare email: string
 
-  @column()
+  @column({ serializeAs: null })
   declare password: string
 
   @column.dateTime({ autoCreate: true })

--- a/src/auth/stubs/make/model/user_with_session.stub
+++ b/src/auth/stubs/make/model/user_with_session.stub
@@ -26,7 +26,7 @@ export default class {{ modelName }} extends compose(BaseModel, AuthFinder) {
   @column()
   declare email: string
 
-  @column()
+  @column({ serializeAs: null })
   declare password: string
 
   @column.dateTime({ autoCreate: true })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I am surprised that v6 template expose password when serialized, which was done correctly in v5 template. This patch should fix it all.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
