### PR TITLE
chore: add back silent auth middleware

### DIFF
--- a/src/auth/main.ts
+++ b/src/auth/main.ts
@@ -98,12 +98,16 @@ export async function presetAuth(
   })
 
   /**
-   * Publish guest middleware only when using the session
+   * Publish guest & silent_auth middleware only when using the session
    * guard
    */
   if (options.guard === 'session') {
     await codemods.makeUsingStub(STUBS_ROOT, 'make/middleware/guest.stub', {
       entity: app.generators.createEntity('guest'),
+    })
+
+    await codemods.makeUsingStub(STUBS_ROOT, 'make/middleware/silent_auth.stub', {
+      entity: app.generators.createEntity('silent_auth'),
     })
   }
 

--- a/src/auth/stubs/make/middleware/silent_auth.stub
+++ b/src/auth/stubs/make/middleware/silent_auth.stub
@@ -1,0 +1,24 @@
+{{#var middlewareName = generators.middlewareName(entity.name)}}
+{{#var middlewareFileName = generators.middlewareFileName(entity.name)}}
+{{{
+  exports({ to: app.middlewarePath(entity.path, middlewareFileName) })
+}}}
+import type { HttpContext } from '@adonisjs/core/http'
+import type { NextFn } from '@adonisjs/core/types/http'
+
+/**
+ * Silent auth middleware can be used as a global middleware to silent check
+ * if the user is logged-in or not.
+ *
+ * The request continues as usual, even when the user is not logged-in.
+ */
+export default class {{ middlewareName }} {
+  async handle(
+    ctx: HttpContext,
+    next: NextFn,
+  ) {
+    await ctx.auth.check()
+
+    return next()
+  }
+}


### PR DESCRIPTION
Hey there! 👋🏻

This PR reintroduces the `SilentAuth` middleware.

**Why was it removed?**

The middleware was previously removed because the preferred approach was to call `auth.check()` directly wherever the `auth.user` variable is needed in your templates. This is often done in files like `header.edge`:

```edge
@if(auth.isAuthenticated || await auth.check())
  {{ auth.user.email }}
@end
```

**Why bring it back?**

There are a few reasons:

1. When using an API with the session guard, there may be no templates involved, making the `SilentAuth` middleware quite useful.
2. Its removal has led to some confusion, as the documentation doesn't clearly explain everything.

---

For these reasons, I believe the silent_auth middleware should be re-added, along with improved documentation on when it can be helpful.