### PR TITLE
Fix(stubs): Add InferAuthenticators import for auth.ts file

### DIFF
--- a/src/auth/stubs/config/access_tokens_with_lucid.stub
+++ b/src/auth/stubs/config/access_tokens_with_lucid.stub
@@ -3,7 +3,7 @@
 }}}
 import { defineConfig } from '@adonisjs/auth'
 import { tokensGuard, tokensUserProvider } from '@adonisjs/auth/access_tokens'
-import type { InferAuthEvents, Authenticators } from '@adonisjs/auth/types'
+import type { InferAuthenticators, InferAuthEvents, Authenticators } from '@adonisjs/auth/types'
 
 const authConfig = defineConfig({
   default: 'api',

--- a/src/auth/stubs/config/basic_auth_with_lucid.stub
+++ b/src/auth/stubs/config/basic_auth_with_lucid.stub
@@ -3,7 +3,7 @@
 }}}
 import { defineConfig } from '@adonisjs/auth'
 import { basicAuthGuard, basicAuthUserProvider } from '@adonisjs/auth/basic_auth'
-import type { InferAuthEvents, Authenticators } from '@adonisjs/auth/types'
+import type { InferAuthenticators, InferAuthEvents, Authenticators } from '@adonisjs/auth/types'
 
 const authConfig = defineConfig({
   default: 'basicAuth',

--- a/src/auth/stubs/config/session_with_lucid.stub
+++ b/src/auth/stubs/config/session_with_lucid.stub
@@ -3,7 +3,7 @@
 }}}
 import { defineConfig } from '@adonisjs/auth'
 import { sessionGuard, sessionUserProvider } from '@adonisjs/auth/session'
-import type { InferAuthEvents, Authenticators } from '@adonisjs/auth/types'
+import type { InferAuthenticators, InferAuthEvents, Authenticators } from '@adonisjs/auth/types'
 
 const authConfig = defineConfig({
   default: 'web',


### PR DESCRIPTION
### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hello,

I've added the import of InferAuthenticators to the 3 stubs, after noticing that they weren't imported as standard. I don't know if this is normal so I'm doing this PR. I haven't tested the code because I don't know how to do it.

Regards 
